### PR TITLE
Feature/aldi/reduce formatting cpu use

### DIFF
--- a/fastime.go
+++ b/fastime.go
@@ -167,8 +167,8 @@ func (f *fastime) Stop() {
 func (f *fastime) stop() {
 	if f.IsDaemonRunning() {
 		atomic.StoreInt64(&f.dur, 0)
-		f.wg.Wait()
 	}
+	f.wg.Wait()
 }
 
 func (f *fastime) Since(t time.Time) time.Duration {
@@ -234,6 +234,11 @@ func (f *fastime) StartTimerD(ctx context.Context, dur time.Duration) Fastime {
 			if t.Sub(lastCorrection) < f.correctionDur {
 				f.update()
 			} else { // correct the system time at a fixed interval
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
 				f.refresh()
 				lastCorrection = t
 			}

--- a/fastime.go
+++ b/fastime.go
@@ -210,7 +210,7 @@ func (f *fastime) StartTimerD(ctx context.Context, dur time.Duration) Fastime {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	// if the daemon was already running, restart
-	if !f.IsDaemonRunning() {
+	if f.IsDaemonRunning() {
 		f.stop()
 	}
 	f.running.Store(true)

--- a/fastime.go
+++ b/fastime.go
@@ -34,7 +34,7 @@ type fastime struct {
 	ut            int64
 	unt           int64
 	correctionDur time.Duration
-	running       *atomic.Value
+	running       atomic.Bool
 	t             *atomic.Value
 	ft            *atomic.Value
 	format        *atomic.Value
@@ -52,12 +52,7 @@ func New() Fastime {
 
 func newFastime() *fastime {
 	f := &fastime{
-		t: new(atomic.Value),
-		running: func() *atomic.Value {
-			av := new(atomic.Value)
-			av.Store(false)
-			return av
-		}(),
+		t:    new(atomic.Value),
 		ut:   math.MaxInt64,
 		unt:  math.MaxInt64,
 		uut:  math.MaxUint32,
@@ -122,7 +117,7 @@ func (f *fastime) store(t time.Time) *fastime {
 }
 
 func (f *fastime) IsDaemonRunning() bool {
-	return f.running.Load().(bool)
+	return f.running.Load()
 }
 
 func (f *fastime) GetLocation() *time.Location {

--- a/fastime_test.go
+++ b/fastime_test.go
@@ -69,6 +69,36 @@ func TestStop(t *testing.T) {
 	}
 }
 
+func TestStartStop(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "check start and stop",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			dur := 10 * time.Millisecond
+			f := New().StartTimerD(ctx, dur)
+			if !f.IsDaemonRunning() {
+				t.Error("daemon should be running")
+			}
+			for i := 0; i < 5; i++ {
+				f.StartTimerD(ctx, dur)
+				if !f.IsDaemonRunning() {
+					t.Error("daemon should be running")
+				}
+				f.Stop()
+				if f.IsDaemonRunning() {
+					t.Error("daemon should not be running")
+				}
+			}
+		})
+	}
+}
+
 func TestFastime_Now(t *testing.T) {
 	type fields struct {
 		t      atomic.Value

--- a/fastime_test.go
+++ b/fastime_test.go
@@ -255,8 +255,10 @@ func TestUnixUNanoNow(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if UnixUNanoNow() != uint32(Now().UnixNano()) {
-				t.Error("time is not correct")
+			exp := UnixUNanoNow()
+			act := uint32(Now().UnixNano())
+			if exp != act {
+				t.Errorf("time is not correct, exp: %v, actual: %v", exp, act)
 			}
 		})
 	}
@@ -274,8 +276,10 @@ func TestFastime_UnixUNanoNow(t *testing.T) {
 	f := New().StartTimerD(context.Background(), time.Nanosecond)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if f.UnixUNanoNow() != uint32(f.Now().UnixNano()) {
-				t.Error("time is not correct")
+			exp := f.UnixUNanoNow()
+			act := uint32(f.Now().UnixNano())
+			if exp != act {
+				t.Errorf("time is not correct, exp: %v, actual: %v", exp, act)
 			}
 		})
 	}


### PR DESCRIPTION
just want to say Fastime is awesome!
Really increased the speed of getting time in our application for logging etc.
We noticed that 10% of our application CPU was being used by the daemon.
The changes in this PR should reduce this by 75%.
- Simplify and remove select statement and reduce to a single ticker for time updates. Accuracy should be fine.
- Do not await context in every loop. Just check it once in a while.
- 50% of the CPU improvement is just from updating the formatted string when the method is called. Our applications do not use this call and the number of updates should be the same.
- Add guards around start/stop to prevent race conditions

Please let me know if you see any issues. Tests pass locally